### PR TITLE
`data` is not required in `getRules` response

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.twitter</groupId>
   <artifactId>twitter-api-java-sdk</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
 </dependency>
 ```
 
@@ -75,7 +75,7 @@ mavenLocal()       // Needed if the 'twitter-api-java-sdk' jar has been publishe
 }
 
 dependencies {
-implementation "com.twitter:twitter-api-java-sdk:2.0.1"
+implementation "com.twitter:twitter-api-java-sdk:2.0.2"
 }
 ```
 
@@ -89,7 +89,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/twitter-api-java-sdk-2.0.1.jar`
+* `target/twitter-api-java-sdk-2.0.2.jar`
 * `target/lib/*.jar`
 
 ## Twitter Credentials

--- a/docs/RulesLookupResponse.md
+++ b/docs/RulesLookupResponse.md
@@ -7,7 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**data** | [**List&lt;Rule&gt;**](Rule.md) |  |  |
+|**data** | [**List&lt;Rule&gt;**](Rule.md) |  |  [optional] |
 |**meta** | [**RulesResponseMetadata**](RulesResponseMetadata.md) |  |  |
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.twitter</groupId>
             <artifactId>twitter-api-java-sdk</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>twitter-api-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>twitter-api-java-sdk</name>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <url>https://github.com/twitterdev/twitter-api-java-sdk</url>
     <description>Twitter API v2 available endpoints</description>
     <scm>

--- a/src/main/java/com/twitter/clientlib/ApiClient.java
+++ b/src/main/java/com/twitter/clientlib/ApiClient.java
@@ -225,7 +225,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("twitter-api-java-sdk/2.0.1");
+        setUserAgent("twitter-api-java-sdk/2.0.2");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/twitter/clientlib/model/RulesLookupResponse.java
+++ b/src/main/java/com/twitter/clientlib/model/RulesLookupResponse.java
@@ -64,7 +64,7 @@ import com.twitter.clientlib.JSON;
 public class RulesLookupResponse {
   public static final String SERIALIZED_NAME_DATA = "data";
   @SerializedName(SERIALIZED_NAME_DATA)
-  private List<Rule> data = new ArrayList<>();
+  private List<Rule> data = null;
 
   public static final String SERIALIZED_NAME_META = "meta";
   @SerializedName(SERIALIZED_NAME_META)
@@ -80,6 +80,9 @@ public class RulesLookupResponse {
   }
 
   public RulesLookupResponse addDataItem(Rule dataItem) {
+    if (this.data == null) {
+      this.data = new ArrayList<>();
+    }
     this.data.add(dataItem);
     return this;
   }
@@ -88,8 +91,8 @@ public class RulesLookupResponse {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
 
   public List<Rule> getData() {
     return data;
@@ -176,7 +179,6 @@ public class RulesLookupResponse {
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
-    openapiRequiredFields.add("data");
     openapiRequiredFields.add("meta");
   }
 

--- a/src/test/java/com/twitter/clientlib/integration/ApiTweetBearerTester.java
+++ b/src/test/java/com/twitter/clientlib/integration/ApiTweetBearerTester.java
@@ -75,18 +75,47 @@ public class ApiTweetBearerTester extends ApiTester {
         .execute();
   }
 
+  private void deleteAllRules() throws ApiException {
+    RulesLookupResponse result = apiInstance.tweets().getRules().execute();
+    if(result.getData() != null) {
+      for(Rule rule : result.getData()) {
+        AddOrDeleteRulesRequest request = new AddOrDeleteRulesRequest();
+        DeleteRulesRequest dr = new DeleteRulesRequest();
+        DeleteRulesRequestDelete drd = new DeleteRulesRequestDelete();
+        drd.setValues(Arrays.asList(rule.getValue()));
+        dr.setDelete(drd);
+        request.setActualInstance(dr);
+        apiInstance.tweets().addOrDeleteRules(request).dryRun(false).execute();
+      }
+    }
+  }
 
-  /* @Test
+  @Test
   public void getRulesAllTest() throws ApiException {
-    GetRulesResponse result = apiInstance.tweets().getRules(null, null, null);
-    assertNotNull(result.getData());
-    assertNotNull(result.getData().get(0));
-    assertNotNull(result.getData().get(0).getValue());
-    assertNotNull(result.getData().get(0).getId());
+    try {
+      addRule(ruleValue);
+      RulesLookupResponse result = apiInstance.tweets().getRules().execute();
+      assertNotNull(result.getData());
+      assertNotNull(result.getData().get(0));
+      assertNotNull(result.getData().get(0).getValue());
+      assertNotNull(result.getData().get(0).getId());
+      assertNotNull(result.getMeta());
+      assertNotNull(result.getMeta().getSent());
+      assertTrue(result.getMeta().getResultCount() > 0);
+    } finally {
+      deleteRule(ruleValue);
+    }
+  }
+
+  @Test
+  public void getRulesNoRulesTest() throws ApiException {
+    deleteAllRules();
+    RulesLookupResponse result = apiInstance.tweets().getRules().execute();
+    assertNull(result.getData());
     assertNotNull(result.getMeta());
     assertNotNull(result.getMeta().getSent());
-    assertTrue(result.getMeta().getResultCount() > 0);
-  } */
+    assertEquals(0, result.getMeta().getResultCount());
+  }
 
   @Test
   public void addOrDeleteRulesAddTest() throws ApiException {


### PR DESCRIPTION
Fix for https://github.com/twitterdev/twitter-api-java-sdk/issues/33
Change `data` to be a non mandatory field in `RulesLookupResponse`