### PR TITLE
Use Jakarta 10 for imports instead of old javax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>twitter-api-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>twitter-api-java-sdk</name>
-    <version>2.0.3</version>
+    <version>2.0.3-jakarta10</version>
     <url>https://github.com/twitterdev/twitter-api-java-sdk</url>
     <description>Twitter API v2 available endpoints</description>
     <scm>
@@ -330,9 +330,9 @@
             <version>${jsr311-api-version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax.ws.rs-api-version}</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta.ws.rs-api-version}</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>
@@ -371,7 +371,7 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>
         <mockito-core-version>3.12.4</mockito-core-version>
-        <javax.ws.rs-api-version>2.1.1</javax.ws.rs-api-version>
+        <jakarta.ws.rs-api-version>3.1.0</jakarta.ws.rs-api-version>
         <jsr311-api-version>1.1.1</jsr311-api-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scribejava-apis-version>8.3.1</scribejava-apis-version>

--- a/src/main/java/com/twitter/clientlib/ApiException.java
+++ b/src/main/java/com/twitter/clientlib/ApiException.java
@@ -25,7 +25,7 @@ package com.twitter.clientlib;
 import java.util.Map;
 import java.util.List;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 /**
  * <p>ApiException class.</p>

--- a/src/main/java/com/twitter/clientlib/api/BookmarksApi.java
+++ b/src/main/java/com/twitter/clientlib/api/BookmarksApi.java
@@ -53,7 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/api/ComplianceApi.java
+++ b/src/main/java/com/twitter/clientlib/api/ComplianceApi.java
@@ -57,7 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/api/GeneralApi.java
+++ b/src/main/java/com/twitter/clientlib/api/GeneralApi.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/api/ListsApi.java
+++ b/src/main/java/com/twitter/clientlib/api/ListsApi.java
@@ -67,7 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/api/SpacesApi.java
+++ b/src/main/java/com/twitter/clientlib/api/SpacesApi.java
@@ -56,7 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/api/TweetsApi.java
+++ b/src/main/java/com/twitter/clientlib/api/TweetsApi.java
@@ -82,7 +82,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/api/UsersApi.java
+++ b/src/main/java/com/twitter/clientlib/api/UsersApi.java
@@ -70,7 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Arrays;
 import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/com/twitter/clientlib/model/AbstractOpenApiSchema.java
+++ b/src/main/java/com/twitter/clientlib/model/AbstractOpenApiSchema.java
@@ -26,7 +26,7 @@ import com.twitter.clientlib.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 //import com.fasterxml.jackson.annotation.JsonValue;
 

--- a/src/main/java/com/twitter/clientlib/model/AddOrDeleteRulesRequest.java
+++ b/src/main/java/com/twitter/clientlib/model/AddOrDeleteRulesRequest.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/src/main/java/com/twitter/clientlib/model/ProblemOrError.java
+++ b/src/main/java/com/twitter/clientlib/model/ProblemOrError.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/src/main/java/com/twitter/clientlib/model/RulesRequestSummary.java
+++ b/src/main/java/com/twitter/clientlib/model/RulesRequestSummary.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/src/main/java/com/twitter/clientlib/model/TweetComplianceData.java
+++ b/src/main/java/com/twitter/clientlib/model/TweetComplianceData.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/src/main/java/com/twitter/clientlib/model/TweetComplianceStreamResponse.java
+++ b/src/main/java/com/twitter/clientlib/model/TweetComplianceStreamResponse.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/src/main/java/com/twitter/clientlib/model/UserComplianceData.java
+++ b/src/main/java/com/twitter/clientlib/model/UserComplianceData.java
@@ -46,7 +46,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/src/main/java/com/twitter/clientlib/model/UserComplianceStreamResponse.java
+++ b/src/main/java/com/twitter/clientlib/model/UserComplianceStreamResponse.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;


### PR DESCRIPTION
### Problem

I cannot use this SDK with newer frameworks (Quarkus 3.2) with Jakarta 10, which has changed its namespace to `jakarta.ws.rs.*` from now legacy `javax.ws.rs.*`. 

Therefore when running it, it throws a `java.lang.ClassNotFoundException: javax.ws.rs.core.GenericType` exception.

### Solution

Changed the dependency and updated the imports.

### Result

Self-explanatory.
